### PR TITLE
fc-kn9j: Enable UCL input validation for CHAP credentials

### DIFF
--- a/ctld-agent/src/ctl/ctl_manager.rs
+++ b/ctld-agent/src/ctl/ctl_manager.rs
@@ -277,7 +277,8 @@ impl CtlManager {
             let auth_group_name = export.auth.auth_group_name(&export.volume_name);
 
             // If this export has authentication, create an auth group entry
-            if let Some(ag) = AuthGroup::from_auth_config(&export.auth, &export.volume_name) {
+            // This validates CHAP credentials don't contain characters that would corrupt UCL
+            if let Some(ag) = AuthGroup::from_auth_config(&export.auth, &export.volume_name)? {
                 auth_groups.push((auth_group_name.clone(), ag));
             }
 


### PR DESCRIPTION
## Summary

Fix medium severity finding from security review (fc-u4b6).

Enables `validate_ucl_string()` for CHAP credentials to prevent UCL parsing failures from special characters.

## Changes

- Remove `#[allow(dead_code)]` from validation function
- Call validation for username and password in auth-group generation
- Add unit tests for special character handling
- Return clear error for invalid credentials

## Testing

- Unit tests for edge cases (", {, }, \, newlines)
- All existing tests pass

Issue: fc-kn9j
Follow-up to: fc-u4b6 (security review)