### PR TITLE
fc-71g3: Fix RwLock panic-poison pattern

### DIFF
--- a/ctld-agent/src/ctl/ctl_manager.rs
+++ b/ctld-agent/src/ctl/ctl_manager.rs
@@ -114,7 +114,8 @@ impl CtlManager {
         let config_path = &self.ucl_manager.config_path;
         let config = CtlConfig::from_file(config_path)?;
 
-        let mut exports = self.exports.write().unwrap();
+        let mut exports = self.exports.write()
+            .map_err(|e| CtlError::ConfigError(format!("Lock poisoned: {}", e)))?;
         let mut loaded_iscsi = 0;
         let mut loaded_nvmeof = 0;
 
@@ -223,7 +224,8 @@ impl CtlManager {
         };
 
         // Use Entry API for atomic check-and-insert
-        let mut exports = self.exports.write().unwrap();
+        let mut exports = self.exports.write()
+            .map_err(|e| CtlError::ConfigError(format!("Lock poisoned: {}", e)))?;
         match exports.entry(volume_name.to_string()) {
             Entry::Occupied(_) => {
                 return Err(CtlError::TargetExists(volume_name.to_string()));
@@ -244,7 +246,8 @@ impl CtlManager {
     pub fn unexport_volume(&self, volume_name: &str) -> Result<()> {
         debug!("Unexporting volume {}", volume_name);
 
-        let mut exports = self.exports.write().unwrap();
+        let mut exports = self.exports.write()
+            .map_err(|e| CtlError::ConfigError(format!("Lock poisoned: {}", e)))?;
         if exports.remove(volume_name).is_none() {
             return Err(CtlError::TargetNotFound(volume_name.to_string()));
         }


### PR DESCRIPTION
Replace `.write().unwrap()` with proper error handling to prevent cascading panics from lock poisoning.

## Changes
- ctl_manager.rs: Replace unwrap with map_err for RwLock operations

Closes: fc-71g3