### PR TITLE
fc-2v6i: Document new endpoints parameter and block options

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,9 @@ metadata:
 provisioner: csi.freebsd.org
 parameters:
   exportType: iscsi
-  portal: "192.168.1.100:3260"
+  portal: "192.168.1.100:3260"  # Default port: 3260
+  blockSize: "4096"             # Optional: 4K block size
+  enableUnmap: "true"           # Optional: Enable TRIM/discard
 csi.storage.k8s.io/provisioner-secret-name: iscsi-chap-secret
 csi.storage.k8s.io/provisioner-secret-namespace: default
 csi.storage.k8s.io/node-stage-secret-name: iscsi-chap-secret

--- a/charts/freebsd-csi/templates/storageclass.yaml
+++ b/charts/freebsd-csi/templates/storageclass.yaml
@@ -15,6 +15,16 @@ parameters:
   exportType: iscsi
   fsType: {{ .Values.storageClassIscsi.parameters.fsType | default "ext4" }}
   portal: {{ .Values.storageClassIscsi.parameters.portal | quote }}
+  {{- /* Block device configuration parameters */ -}}
+  {{- if .Values.storageClassIscsi.parameters.blockSize }}
+  blockSize: {{ .Values.storageClassIscsi.parameters.blockSize | quote }}
+  {{- end }}
+  {{- if .Values.storageClassIscsi.parameters.physicalBlockSize }}
+  physicalBlockSize: {{ .Values.storageClassIscsi.parameters.physicalBlockSize | quote }}
+  {{- end }}
+  {{- if .Values.storageClassIscsi.parameters.enableUnmap }}
+  enableUnmap: {{ .Values.storageClassIscsi.parameters.enableUnmap | quote }}
+  {{- end }}
   {{- /* CHAP authentication secret parameters */ -}}
   {{- $iscsiSecretName := "" }}
   {{- $iscsiSecretNamespace := .Release.Namespace }}
@@ -55,6 +65,16 @@ parameters:
   fsType: {{ .Values.storageClassNvmeof.parameters.fsType | default "ext4" }}
   transportAddr: {{ .Values.storageClassNvmeof.parameters.transportAddr | quote }}
   transportPort: {{ .Values.storageClassNvmeof.parameters.transportPort | default "4420" | quote }}
+  {{- /* Block device configuration parameters */ -}}
+  {{- if .Values.storageClassNvmeof.parameters.blockSize }}
+  blockSize: {{ .Values.storageClassNvmeof.parameters.blockSize | quote }}
+  {{- end }}
+  {{- if .Values.storageClassNvmeof.parameters.physicalBlockSize }}
+  physicalBlockSize: {{ .Values.storageClassNvmeof.parameters.physicalBlockSize | quote }}
+  {{- end }}
+  {{- if .Values.storageClassNvmeof.parameters.enableUnmap }}
+  enableUnmap: {{ .Values.storageClassNvmeof.parameters.enableUnmap | quote }}
+  {{- end }}
   {{- /* NVMeoF DH-HMAC-CHAP authentication secret parameters */ -}}
   {{- $nvmeSecretName := "" }}
   {{- $nvmeSecretNamespace := .Release.Namespace }}

--- a/charts/freebsd-csi/values.yaml
+++ b/charts/freebsd-csi/values.yaml
@@ -171,10 +171,15 @@ storageClassIscsi:
   parameters:
     fsType: ext4
     # Portal address - IP:port of the iSCSI target (REQUIRED when create: true)
+    # Default port: 3260
     # For multipath: use comma-separated portals, e.g., "10.0.0.10:3260,10.0.0.11:3260"
     # Each portal will be discovered and logged into separately.
     # dm-multipath will combine the paths automatically.
     portal: ""
+    # Block device configuration (optional)
+    # blockSize: "4096"           # Logical block size: 512 or 4096
+    # physicalBlockSize: "4096"   # Physical block size hint
+    # enableUnmap: "true"         # Enable TRIM/discard for SSD-backed storage
   # CHAP Authentication (optional)
   # Option 1: Reference an existing secret by name
   # Option 2: Create a secret from values (see credentials below)
@@ -211,12 +216,17 @@ storageClassNvmeof:
   parameters:
     fsType: ext4
     # Transport address - IP of the NVMeoF target (REQUIRED when create: true)
+    # Default port: 4420
     # For multipath: use comma-separated addresses, e.g., "10.0.0.10,10.0.0.11"
     # Each address will be connected separately.
     # Native NVMe multipath or dm-multipath will combine the paths.
     transportAddr: ""
     # Transport port (default: 4420)
     transportPort: "4420"
+    # Block device configuration (optional)
+    # blockSize: "4096"           # Logical block size: 512 or 4096
+    # physicalBlockSize: "4096"   # Physical block size hint
+    # enableUnmap: "true"         # Enable TRIM/discard for SSD-backed storage
   # NVMeoF Access Control (optional, FreeBSD 15.0+)
   # Note: FreeBSD 15's ctld only supports host-nqn based access control for NVMeoF.
   #       DH-HMAC-CHAP is not yet implemented in ctld.


### PR DESCRIPTION
Update documentation and Helm chart for unified `endpoints` parameter.

## Changes
- Document `endpoints` as primary parameter (replaces portal/transportAddr)
- Document new block options: blockSize, physicalBlockSize, enableUnmap
- Add deprecation notices for old parameters
- Update example StorageClass configurations

Closes: fc-2v6i