### PR TITLE
fc-nb3p: Add DevicePath whitelist validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "csi-driver"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "clap",
  "hostname",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "ctld-agent"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "clap",
  "futures",

--- a/ctld-agent/src/main.rs
+++ b/ctld-agent/src/main.rs
@@ -119,6 +119,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let zfs = Arc::new(RwLock::new(zfs_manager));
 
     // Initialize unified CTL manager for iSCSI and NVMeoF exports
+    // Pass parent_dataset for device path validation (security: prevents privilege escalation)
     let ctl_manager = CtlManager::new(
         args.base_iqn.clone(),
         args.base_nqn.clone(),
@@ -126,6 +127,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         args.ctl_config.to_string_lossy().to_string(),
         args.auth_group.clone(),
         args.transport_group_name.clone(),
+        args.zfs_parent.clone(),
     )?;
 
     // Note: We intentionally do NOT load from UCL config here.


### PR DESCRIPTION
Restrict device paths to the configured ZFS parent dataset to prevent privilege escalation.

## Changes
- Validate paths start with `/dev/zvol/{parent_dataset}/`
- Block path traversal (`../`)
- Return clear error for invalid paths

## Security
Prevents exporting arbitrary files/devices via iSCSI/NVMeoF.

Closes: fc-nb3p