### PR TITLE
fix: use RELEASE_PAT for prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,11 +18,11 @@ jobs:
     name: Create Release PR
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
+      # Use PAT for checkout to enable push and PR creation
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Get current version
         id: current
@@ -86,7 +86,7 @@ jobs:
 
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
           TAG: ${{ steps.bump.outputs.tag }}
           VERSION: ${{ steps.bump.outputs.version }}
         run: |


### PR DESCRIPTION
## Summary

Fix the prepare-release workflow to use a PAT instead of GITHUB_TOKEN.

### Problem

`GITHUB_TOKEN` cannot create PRs that trigger other workflows (GitHub security limitation).

### Solution

Use `RELEASE_PAT` secret for:
- Checkout (enables authenticated push)
- PR creation (enables workflow triggers on the created PR)

### Setup Required

Create a fine-grained PAT at GitHub → Settings → Developer settings → Personal access tokens:
- **Repository access**: Select `freebsd-csi-driver`
- **Permissions**:
  - `Contents`: Read and write
  - `Pull requests`: Read and write

Add it as a repository secret named `RELEASE_PAT`.

---

Generated with [Claude Code](https://claude.com/claude-code)