### PR TITLE
fix(helm): remove read-only constraint on /sys mount for NVMe disconnect

### DIFF
--- a/charts/freebsd-csi/templates/node-daemonset.yaml
+++ b/charts/freebsd-csi/templates/node-daemonset.yaml
@@ -88,7 +88,7 @@ spec:
               # iSCSI discovery needs to write to /etc/iscsi/send_targets/
             - name: host-sys
               mountPath: /sys
-              readOnly: true
+              # NVMe disconnect requires write access to /sys to remove controllers
             {{- if .Values.tls.enabled }}
             - name: tls-certs
               mountPath: /etc/csi-tls


### PR DESCRIPTION
## Summary

- Remove `readOnly: true` from the `/sys` (sysfs) volume mount in the CSI node DaemonSet
- NVMe disconnect requires write access to `/sys/class/nvme-subsystem/*/delete` to remove controllers

## Problem

The `nvme disconnect` command was failing silently inside the CSI driver container:
```
NQN:nqn.2024-01.org.freebsd.csi:pvc-... disconnected 0 controller(s)
nvme0: failed to disconnect, error 30
```

Error 30 = EROFS (Read-only file system). The command returned success but didn't actually disconnect, leaving NVMe devices stuck in "connecting" state after PVC deletion.

## Root Cause

The Helm chart mounted `/sys` with `readOnly: true`, which is a reasonable security default for most containers, but CSI node drivers need write access for storage operations like NVMe disconnect.

## Test plan

- [x] Created test PVC with NVMeoF storage class
- [x] Deleted PVC and verified disconnect succeeds with "disconnected 1 controller(s)"
- [x] Verified NVMe subsystem is removed from host after deletion
- [x] Confirmed no "ERROR NVMeoF target still connected after disconnect" in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)