### PR TITLE
fc-o4zr: Remove deprecated StorageClass parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "csi-driver"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "clap",
  "hostname",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "ctld-agent"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "clap",
  "futures",

--- a/csi-driver/src/controller.rs
+++ b/csi-driver/src/controller.rs
@@ -344,7 +344,6 @@ impl ControllerService {
         volume_context.insert("export_type".to_string(), export_type_str.to_string());
 
         // Pass through portal/address info for node service (required on Linux)
-        // Supports both legacy parameters (portal, transportAddr) and new unified 'endpoints'
         // endpoints format: "ip:port,ip:port,..." (first endpoint used for single-path)
         if let Some(endpoints) = parameters.get("endpoints") {
             // Parse endpoints - take first one for connection
@@ -369,35 +368,10 @@ impl ControllerService {
                     _ => {}
                 }
             }
-        } else {
-            // Legacy parameter support
-            if let Some(portal) = parameters
-                .get("portal")
-                .or_else(|| parameters.get("targetPortal"))
-            {
-                volume_context.insert("portal".to_string(), portal.clone());
-            }
-
-            // For NVMeoF, pass transport address and port
-            if let Some(addr) = parameters
-                .get("transportAddr")
-                .or_else(|| parameters.get("transport_addr"))
-            {
-                volume_context.insert("transport_addr".to_string(), addr.clone());
-            }
-            if let Some(port) = parameters
-                .get("transportPort")
-                .or_else(|| parameters.get("transport_port"))
-            {
-                volume_context.insert("transport_port".to_string(), port.clone());
-            }
         }
 
         // Pass through filesystem type for node service
-        if let Some(fs_type) = parameters
-            .get("fsType")
-            .or_else(|| parameters.get("fs_type"))
-        {
+        if let Some(fs_type) = parameters.get("fs_type") {
             volume_context.insert("fs_type".to_string(), fs_type.clone());
         }
 

--- a/csi-driver/src/node.rs
+++ b/csi-driver/src/node.rs
@@ -456,7 +456,6 @@ impl NodeService {
         // Fall back to volume_context
         let fs_type_raw = volume_context
             .get("fs_type")
-            .or_else(|| volume_context.get("fsType"))
             .map(|s| s.as_str())
             .unwrap_or("");
 
@@ -548,20 +547,9 @@ impl csi::node_server::Node for NodeService {
             .unwrap_or("iscsi");
 
         // Get portal/address info (required on Linux, optional on FreeBSD)
-        let portal = volume_context
-            .get("portal")
-            .or_else(|| volume_context.get("targetPortal"))
-            .map(|s| s.as_str());
-
-        let transport_addr = volume_context
-            .get("transport_addr")
-            .or_else(|| volume_context.get("transportAddr"))
-            .map(|s| s.as_str());
-
-        let transport_port = volume_context
-            .get("transport_port")
-            .or_else(|| volume_context.get("transportPort"))
-            .map(|s| s.as_str());
+        let portal = volume_context.get("portal").map(|s| s.as_str());
+        let transport_addr = volume_context.get("transport_addr").map(|s| s.as_str());
+        let transport_port = volume_context.get("transport_port").map(|s| s.as_str());
 
         // Check if already staged
         if is_block {

--- a/docs/chap-setup.md
+++ b/docs/chap-setup.md
@@ -93,7 +93,7 @@ metadata:
 provisioner: csi.freebsd.org
 parameters:
   exportType: iscsi
-  portal: "192.168.1.100:3260"
+  endpoints: "192.168.1.100:3260"
 # Reference the CHAP secret for volume provisioning
 csi.storage.k8s.io/provisioner-secret-name: iscsi-chap-secret
 csi.storage.k8s.io/provisioner-secret-namespace: default

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -280,12 +280,10 @@ StorageClass parameters control how volumes are provisioned:
 | Parameter | Values | Default | Description |
 |-----------|--------|---------|-------------|
 | `exportType` | `iscsi`, `nvmeof` | `iscsi` | Protocol for exporting volumes |
-| `fsType` | `ext4`, `xfs` (Linux); `ufs` (FreeBSD) | `ext4` | Filesystem type for formatting volumes |
-| `portal` | `<ip>:<port>[,<ip2>:<port2>...]` | - | **Required for iSCSI on Linux.** iSCSI portal address(es). Default port: 3260 |
-| `transportAddr` | `<ip>[,<ip2>...]` | - | **Required for NVMeoF.** NVMe-oF transport address(es) |
-| `transportPort` | `<port>` | `4420` | NVMe-oF transport port |
+| `fs_type` | `ext4`, `xfs` (Linux); `ufs` (FreeBSD) | `ext4` | Filesystem type for formatting volumes |
+| `endpoints` | `<ip>:<port>[,<ip2>:<port2>...]` | - | **Required on Linux.** Comma-separated list of target endpoints. Default ports: iSCSI=3260, NVMeoF=4420 |
 
-> **Multipath Support:** Both `portal` and `transportAddr` accept comma-separated values for multipath configurations.
+> **Multipath Support:** The `endpoints` parameter accepts comma-separated values for multipath configurations.
 > For iSCSI, each portal will be discovered and logged into separately. For NVMeoF, each address will be connected separately.
 > Native multipath (NVMe) or dm-multipath (iSCSI) will combine the paths automatically.
 
@@ -301,12 +299,12 @@ StorageClass parameters control how volumes are provisioned:
 
 #### Filesystem Types by Platform
 
-| Platform | Supported fsType | Default |
+| Platform | Supported fs_type | Default |
 |----------|-----------------|---------|
 | Linux | `ext4`, `xfs` | `ext4` |
 | FreeBSD | `ufs` | `ufs` |
 
-> **Note:** `zfs` cannot be used as `fsType` because ZFS manages its own storage layer and cannot format block devices.
+> **Note:** `zfs` cannot be used as `fs_type` because ZFS manages its own storage layer and cannot format block devices.
 
 #### Example StorageClasses
 
@@ -319,10 +317,10 @@ metadata:
 provisioner: csi.freebsd.org
 parameters:
   exportType: iscsi
-  fsType: ext4
-  portal: "192.168.1.100:3260"  # REQUIRED for Linux (default port: 3260)
-  blockSize: "4096"             # Optional: 4K block size
-  enableUnmap: "true"           # Optional: Enable TRIM/discard
+  fs_type: ext4
+  endpoints: "192.168.1.100:3260"  # REQUIRED for Linux (default port: 3260)
+  blockSize: "4096"                # Optional: 4K block size
+  enableUnmap: "true"              # Optional: Enable TRIM/discard
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
@@ -337,9 +335,9 @@ metadata:
 provisioner: csi.freebsd.org
 parameters:
   exportType: iscsi
-  fsType: ext4
-  # Multiple portals for multipath - dm-multipath combines paths automatically
-  portal: "10.0.0.1:3260,10.0.0.2:3260"
+  fs_type: ext4
+  # Multiple endpoints for multipath - dm-multipath combines paths automatically
+  endpoints: "10.0.0.1:3260,10.0.0.2:3260"
   blockSize: "4096"
   enableUnmap: "true"
 allowVolumeExpansion: true
@@ -356,9 +354,8 @@ metadata:
 provisioner: csi.freebsd.org
 parameters:
   exportType: nvmeof
-  fsType: ext4
-  transportAddr: "192.168.1.100"  # REQUIRED (default port: 4420)
-  transportPort: "4420"
+  fs_type: ext4
+  endpoints: "192.168.1.100:4420"  # REQUIRED (default port: 4420)
   blockSize: "4096"
   enableUnmap: "true"
 allowVolumeExpansion: true
@@ -375,10 +372,9 @@ metadata:
 provisioner: csi.freebsd.org
 parameters:
   exportType: nvmeof
-  fsType: ext4
-  # Multiple addresses for multipath - native NVMe multipath combines paths
-  transportAddr: "10.0.0.1,10.0.0.2"
-  transportPort: "4420"
+  fs_type: ext4
+  # Multiple endpoints for multipath - native NVMe multipath combines paths
+  endpoints: "10.0.0.1:4420,10.0.0.2:4420"
   blockSize: "4096"
 allowVolumeExpansion: true
 reclaimPolicy: Delete
@@ -394,8 +390,8 @@ metadata:
 provisioner: csi.freebsd.org
 parameters:
   exportType: iscsi
-  fsType: ext4
-  portal: "192.168.1.100:3260"
+  fs_type: ext4
+  endpoints: "192.168.1.100:3260"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -257,7 +257,7 @@ helm install freebsd-csi oci://ghcr.io/ndenev/charts/freebsd-csi \
   --create-namespace \
   --set agent.endpoint=http://<FREEBSD-STORAGE-IP>:50051 \
   --set storageClassIscsi.create=true \
-  --set storageClassIscsi.parameters.portal=<FREEBSD-STORAGE-IP>:3260
+  --set storageClassIscsi.parameters.endpoints=<FREEBSD-STORAGE-IP>:3260
 
 # NVMeoF StorageClass (FreeBSD 15.0+)
 helm install freebsd-csi oci://ghcr.io/ndenev/charts/freebsd-csi \
@@ -265,7 +265,7 @@ helm install freebsd-csi oci://ghcr.io/ndenev/charts/freebsd-csi \
   --create-namespace \
   --set agent.endpoint=http://<FREEBSD-STORAGE-IP>:50051 \
   --set storageClassNvmeof.create=true \
-  --set storageClassNvmeof.parameters.transportAddr=<FREEBSD-STORAGE-IP>
+  --set storageClassNvmeof.parameters.endpoints=<FREEBSD-STORAGE-IP>:4420
 ```
 
 **Option 2: Create manually after installation**
@@ -279,8 +279,8 @@ metadata:
 provisioner: csi.freebsd.org
 parameters:
   exportType: iscsi
-  fsType: ext4
-  portal: "<FREEBSD-STORAGE-IP>:3260"
+  fs_type: ext4
+  endpoints: "<FREEBSD-STORAGE-IP>:3260"
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
@@ -295,9 +295,8 @@ metadata:
 provisioner: csi.freebsd.org
 parameters:
   exportType: nvmeof
-  fsType: ext4
-  transportAddr: "<FREEBSD-STORAGE-IP>"
-  transportPort: "4420"
+  fs_type: ext4
+  endpoints: "<FREEBSD-STORAGE-IP>:4420"
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: Immediate


### PR DESCRIPTION
## Summary
Remove legacy StorageClass parameter names after deprecation period.

## Breaking Changes
- Removed `portal`, `targetPortal` → use `endpoints`
- Removed `transportAddr`, `transport_addr` → use `endpoints`
- Removed `transportPort`, `transport_port` → use `endpoints`
- Standardized `fs_type` (removed `fsType`)

## Issue
fc-o4zr

🤖 Generated with [Claude Code](https://claude.com/claude-code)