### PR TITLE
feat(zfs): refactor ListSnapshots to query ZFS directly

### DIFF
--- a/ctld-agent/src/zfs/mod.rs
+++ b/ctld-agent/src/zfs/mod.rs
@@ -2,7 +2,7 @@ pub mod dataset;
 pub mod error;
 pub mod properties;
 
-pub use dataset::{Capacity, Dataset, FindSnapshotResult, ZfsManager};
+pub use dataset::{Capacity, CsiSnapshotInfo, Dataset, FindSnapshotResult, ZfsManager};
 // Re-export for module API
 #[allow(unused_imports)]
 pub use error::{Result, ZfsError};


### PR DESCRIPTION
## Summary
- Remove in-memory `SnapshotMetadata` cache - ZFS is single source of truth
- Add `list_csi_snapshots()` to query snapshots with CSI metadata properties
- Snapshot list now survives restarts

## Test plan
- [x] Existing snapshot tests still pass
- [x] Manual verification of ZFS query output

🤖 Generated with [Claude Code](https://claude.com/claude-code)