### PR TITLE
[codex] Add NVMe-oF connect options

### DIFF
--- a/charts/freebsd-csi/README.md
+++ b/charts/freebsd-csi/README.md
@@ -75,7 +75,7 @@ helm install freebsd-csi charts/freebsd-csi \
 | `storageClassNvmeof.parameters.nrIoQueues` | Linux `nvme connect --nr-io-queues` value | - |
 | `storageClassNvmeof.parameters.queueSize` | Linux `nvme connect --queue-size` value | - |
 | `storageClassNvmeof.parameters.disableSqflow` | Linux `nvme connect --disable-sqflow` toggle | - |
-| `storageClassNvmeof.parameters.keepAliveTmo` | Linux `nvme connect --keep-alive-tmo` seconds | - |
+| `storageClassNvmeof.parameters.keepAliveTmo` | Linux `nvme connect --keep-alive-tmo` seconds; `0` disables keepalives | - |
 | `storageClassNvmeof.parameters.reconnectDelay` | Linux `nvme connect --reconnect-delay` seconds | - |
 | `storageClassNvmeof.parameters.ctrlLossTmo` | Linux `nvme connect --ctrl-loss-tmo` seconds; `-1` retries forever | - |
 | `storageClassNvmeof.authSecret.name` | Existing secret with NVMeoF auth credentials | `""` |

--- a/charts/freebsd-csi/README.md
+++ b/charts/freebsd-csi/README.md
@@ -77,7 +77,7 @@ helm install freebsd-csi charts/freebsd-csi \
 | `storageClassNvmeof.parameters.disableSqflow` | Linux `nvme connect --disable-sqflow` toggle | - |
 | `storageClassNvmeof.parameters.keepAliveTmo` | Linux `nvme connect --keep-alive-tmo` seconds | - |
 | `storageClassNvmeof.parameters.reconnectDelay` | Linux `nvme connect --reconnect-delay` seconds | - |
-| `storageClassNvmeof.parameters.ctrlLossTmo` | Linux `nvme connect --ctrl-loss-tmo` seconds | - |
+| `storageClassNvmeof.parameters.ctrlLossTmo` | Linux `nvme connect --ctrl-loss-tmo` seconds; `-1` retries forever | - |
 | `storageClassNvmeof.authSecret.name` | Existing secret with NVMeoF auth credentials | `""` |
 | `storageClassNvmeof.authSecret.namespace` | Namespace of auth secret | Release namespace |
 | `storageClassNvmeof.authSecret.credentials.hostNqn` | Host NQN for access control (creates secret if set) | `""` |

--- a/charts/freebsd-csi/README.md
+++ b/charts/freebsd-csi/README.md
@@ -72,6 +72,12 @@ helm install freebsd-csi charts/freebsd-csi \
 | `storageClassNvmeof.parameters.blockSize` | Logical block size (512 or 4096) | - |
 | `storageClassNvmeof.parameters.physicalBlockSize` | Physical block size hint | - |
 | `storageClassNvmeof.parameters.enableUnmap` | Enable TRIM/discard for SSD-backed storage | - |
+| `storageClassNvmeof.parameters.nrIoQueues` | Linux `nvme connect --nr-io-queues` value | - |
+| `storageClassNvmeof.parameters.queueSize` | Linux `nvme connect --queue-size` value | - |
+| `storageClassNvmeof.parameters.disableSqflow` | Linux `nvme connect --disable-sqflow` toggle | - |
+| `storageClassNvmeof.parameters.keepAliveTmo` | Linux `nvme connect --keep-alive-tmo` seconds | - |
+| `storageClassNvmeof.parameters.reconnectDelay` | Linux `nvme connect --reconnect-delay` seconds | - |
+| `storageClassNvmeof.parameters.ctrlLossTmo` | Linux `nvme connect --ctrl-loss-tmo` seconds | - |
 | `storageClassNvmeof.authSecret.name` | Existing secret with NVMeoF auth credentials | `""` |
 | `storageClassNvmeof.authSecret.namespace` | Namespace of auth secret | Release namespace |
 | `storageClassNvmeof.authSecret.credentials.hostNqn` | Host NQN for access control (creates secret if set) | `""` |

--- a/charts/freebsd-csi/templates/storageclass.yaml
+++ b/charts/freebsd-csi/templates/storageclass.yaml
@@ -91,22 +91,22 @@ parameters:
   enableUnmap: {{ .Values.storageClassNvmeof.parameters.enableUnmap | quote }}
   {{- end }}
   {{- /* Linux NVMeoF initiator connect options */ -}}
-  {{- if .Values.storageClassNvmeof.parameters.nrIoQueues }}
+  {{- if hasKey .Values.storageClassNvmeof.parameters "nrIoQueues" }}
   nvmeof.nrIoQueues: {{ .Values.storageClassNvmeof.parameters.nrIoQueues | quote }}
   {{- end }}
-  {{- if .Values.storageClassNvmeof.parameters.queueSize }}
+  {{- if hasKey .Values.storageClassNvmeof.parameters "queueSize" }}
   nvmeof.queueSize: {{ .Values.storageClassNvmeof.parameters.queueSize | quote }}
   {{- end }}
   {{- if .Values.storageClassNvmeof.parameters.disableSqflow }}
   nvmeof.disableSqflow: {{ .Values.storageClassNvmeof.parameters.disableSqflow | quote }}
   {{- end }}
-  {{- if .Values.storageClassNvmeof.parameters.keepAliveTmo }}
+  {{- if hasKey .Values.storageClassNvmeof.parameters "keepAliveTmo" }}
   nvmeof.keepAliveTmo: {{ .Values.storageClassNvmeof.parameters.keepAliveTmo | quote }}
   {{- end }}
-  {{- if .Values.storageClassNvmeof.parameters.reconnectDelay }}
+  {{- if hasKey .Values.storageClassNvmeof.parameters "reconnectDelay" }}
   nvmeof.reconnectDelay: {{ .Values.storageClassNvmeof.parameters.reconnectDelay | quote }}
   {{- end }}
-  {{- if .Values.storageClassNvmeof.parameters.ctrlLossTmo }}
+  {{- if hasKey .Values.storageClassNvmeof.parameters "ctrlLossTmo" }}
   nvmeof.ctrlLossTmo: {{ .Values.storageClassNvmeof.parameters.ctrlLossTmo | quote }}
   {{- end }}
   {{- /* NVMeoF DH-HMAC-CHAP authentication secret parameters */ -}}

--- a/charts/freebsd-csi/templates/storageclass.yaml
+++ b/charts/freebsd-csi/templates/storageclass.yaml
@@ -90,6 +90,25 @@ parameters:
   {{- if .Values.storageClassNvmeof.parameters.enableUnmap }}
   enableUnmap: {{ .Values.storageClassNvmeof.parameters.enableUnmap | quote }}
   {{- end }}
+  {{- /* Linux NVMeoF initiator connect options */ -}}
+  {{- if .Values.storageClassNvmeof.parameters.nrIoQueues }}
+  nvmeof.nrIoQueues: {{ .Values.storageClassNvmeof.parameters.nrIoQueues | quote }}
+  {{- end }}
+  {{- if .Values.storageClassNvmeof.parameters.queueSize }}
+  nvmeof.queueSize: {{ .Values.storageClassNvmeof.parameters.queueSize | quote }}
+  {{- end }}
+  {{- if .Values.storageClassNvmeof.parameters.disableSqflow }}
+  nvmeof.disableSqflow: {{ .Values.storageClassNvmeof.parameters.disableSqflow | quote }}
+  {{- end }}
+  {{- if .Values.storageClassNvmeof.parameters.keepAliveTmo }}
+  nvmeof.keepAliveTmo: {{ .Values.storageClassNvmeof.parameters.keepAliveTmo | quote }}
+  {{- end }}
+  {{- if .Values.storageClassNvmeof.parameters.reconnectDelay }}
+  nvmeof.reconnectDelay: {{ .Values.storageClassNvmeof.parameters.reconnectDelay | quote }}
+  {{- end }}
+  {{- if .Values.storageClassNvmeof.parameters.ctrlLossTmo }}
+  nvmeof.ctrlLossTmo: {{ .Values.storageClassNvmeof.parameters.ctrlLossTmo | quote }}
+  {{- end }}
   {{- /* NVMeoF DH-HMAC-CHAP authentication secret parameters */ -}}
   {{- $nvmeSecretName := "" }}
   {{- $nvmeSecretNamespace := .Release.Namespace }}

--- a/charts/freebsd-csi/values.yaml
+++ b/charts/freebsd-csi/values.yaml
@@ -242,7 +242,7 @@ storageClassNvmeof:
     # disableSqflow: "true"       # --disable-sqflow
     # keepAliveTmo: "5"           # --keep-alive-tmo
     # reconnectDelay: "2"         # --reconnect-delay
-    # ctrlLossTmo: "60"           # --ctrl-loss-tmo
+    # ctrlLossTmo: "60"           # --ctrl-loss-tmo (-1 retries forever)
   # NVMeoF Access Control (optional, FreeBSD 15.0+)
   # Note: FreeBSD 15's ctld only supports host-nqn based access control for NVMeoF.
   #       DH-HMAC-CHAP is not yet implemented in ctld.

--- a/charts/freebsd-csi/values.yaml
+++ b/charts/freebsd-csi/values.yaml
@@ -236,6 +236,13 @@ storageClassNvmeof:
     # blockSize: "4096"           # Logical block size: 512 or 4096
     # physicalBlockSize: "4096"   # Physical block size hint
     # enableUnmap: "true"         # Enable TRIM/discard for SSD-backed storage
+    # Linux nvme-cli connect options (optional)
+    # nrIoQueues: "2"             # --nr-io-queues
+    # queueSize: "128"            # --queue-size
+    # disableSqflow: "true"       # --disable-sqflow
+    # keepAliveTmo: "5"           # --keep-alive-tmo
+    # reconnectDelay: "2"         # --reconnect-delay
+    # ctrlLossTmo: "60"           # --ctrl-loss-tmo
   # NVMeoF Access Control (optional, FreeBSD 15.0+)
   # Note: FreeBSD 15's ctld only supports host-nqn based access control for NVMeoF.
   #       DH-HMAC-CHAP is not yet implemented in ctld.

--- a/charts/freebsd-csi/values.yaml
+++ b/charts/freebsd-csi/values.yaml
@@ -240,7 +240,7 @@ storageClassNvmeof:
     # nrIoQueues: "2"             # --nr-io-queues
     # queueSize: "128"            # --queue-size
     # disableSqflow: "true"       # --disable-sqflow
-    # keepAliveTmo: "5"           # --keep-alive-tmo
+    # keepAliveTmo: "5"           # --keep-alive-tmo (0 disables keepalives)
     # reconnectDelay: "2"         # --reconnect-delay
     # ctrlLossTmo: "60"           # --ctrl-loss-tmo (-1 retries forever)
   # NVMeoF Access Control (optional, FreeBSD 15.0+)

--- a/csi-driver/src/controller.rs
+++ b/csi-driver/src/controller.rs
@@ -16,7 +16,7 @@ use crate::agent::{
 use crate::agent_client::{AgentClient, TlsConfig};
 use crate::csi;
 use crate::metrics::{self, OperationTimer};
-use crate::types::{CloneMode, ExportType, ProvisioningMode};
+use crate::types::{CloneMode, ExportType, NvmeofConnectOptions, ProvisioningMode};
 
 // Standard CSI secret keys for iSCSI CHAP authentication
 // These follow the Linux open-iscsi naming conventions used by the CSI spec
@@ -354,6 +354,14 @@ impl ControllerService {
             volume_context.insert("fsType".to_string(), fs_type.clone());
         }
 
+        if export_type == ExportType::Nvmeof {
+            for key in NvmeofConnectOptions::PARAM_NAMES {
+                if let Some(value) = parameters.get(*key) {
+                    volume_context.insert((*key).to_string(), value.clone());
+                }
+            }
+        }
+
         csi::Volume {
             capacity_bytes: volume.size_bytes,
             volume_id: volume.id.clone(),
@@ -399,6 +407,13 @@ impl csi::controller_server::Controller for ControllerService {
 
         let size_bytes = Self::get_volume_size(req.capacity_range.as_ref());
         let export_type = Self::parse_export_type(&req.parameters);
+
+        if export_type == ExportType::Nvmeof
+            && let Err(e) = NvmeofConnectOptions::parse(&req.parameters)
+        {
+            timer.failure("invalid_argument");
+            return Err(Status::invalid_argument(e.to_string()));
+        }
 
         // Extract authentication credentials from CSI secrets
         let auth = Self::extract_auth_credentials(&req.secrets, export_type);
@@ -1071,6 +1086,75 @@ mod tests {
             ControllerService::parse_export_type(&params),
             ExportType::Nvmeof
         );
+    }
+
+    #[test]
+    fn test_agent_volume_to_csi_preserves_nvmeof_connect_options() {
+        let volume = crate::agent::Volume {
+            id: "vol-1".to_string(),
+            name: "test".to_string(),
+            size_bytes: 1024,
+            zfs_dataset: "tank/vol-1".to_string(),
+            export_type: crate::agent::ExportType::Nvmeof as i32,
+            target_name: "nqn.2024-01.org.freebsd.csi:vol-1".to_string(),
+            lun_id: 0,
+            parameters: HashMap::new(),
+        };
+        let mut params = HashMap::new();
+        params.insert("endpoints".to_string(), "10.0.0.10:4420".to_string());
+        params.insert("nvmeof.nrIoQueues".to_string(), "2".to_string());
+        params.insert("nvmeof.queueSize".to_string(), "128".to_string());
+        params.insert("nvmeof.disableSqflow".to_string(), "true".to_string());
+        params.insert("nvmeof.keepAliveTmo".to_string(), "5".to_string());
+        params.insert("nvmeof.reconnectDelay".to_string(), "2".to_string());
+        params.insert("nvmeof.ctrlLossTmo".to_string(), "60".to_string());
+
+        let csi_volume = ControllerService::agent_volume_to_csi(&volume, &params, None);
+
+        assert_eq!(
+            csi_volume.volume_context.get("nvmeof.nrIoQueues"),
+            Some(&"2".to_string())
+        );
+        assert_eq!(
+            csi_volume.volume_context.get("nvmeof.queueSize"),
+            Some(&"128".to_string())
+        );
+        assert_eq!(
+            csi_volume.volume_context.get("nvmeof.disableSqflow"),
+            Some(&"true".to_string())
+        );
+        assert_eq!(
+            csi_volume.volume_context.get("nvmeof.keepAliveTmo"),
+            Some(&"5".to_string())
+        );
+        assert_eq!(
+            csi_volume.volume_context.get("nvmeof.reconnectDelay"),
+            Some(&"2".to_string())
+        );
+        assert_eq!(
+            csi_volume.volume_context.get("nvmeof.ctrlLossTmo"),
+            Some(&"60".to_string())
+        );
+    }
+
+    #[test]
+    fn test_agent_volume_to_csi_omits_nvmeof_connect_options_for_iscsi() {
+        let volume = crate::agent::Volume {
+            id: "vol-1".to_string(),
+            name: "test".to_string(),
+            size_bytes: 1024,
+            zfs_dataset: "tank/vol-1".to_string(),
+            export_type: crate::agent::ExportType::Iscsi as i32,
+            target_name: "iqn.2024-01.org.freebsd.csi:vol-1".to_string(),
+            lun_id: 0,
+            parameters: HashMap::new(),
+        };
+        let mut params = HashMap::new();
+        params.insert("nvmeof.nrIoQueues".to_string(), "2".to_string());
+
+        let csi_volume = ControllerService::agent_volume_to_csi(&volume, &params, None);
+
+        assert!(!csi_volume.volume_context.contains_key("nvmeof.nrIoQueues"));
     }
 
     #[test]

--- a/csi-driver/src/node.rs
+++ b/csi-driver/src/node.rs
@@ -31,7 +31,7 @@ use std::collections::HashMap;
 use crate::csi;
 use crate::platform;
 use crate::platform::{IscsiChapCredentials, NvmeAuthCredentials};
-use crate::types::{Endpoints, ExportType};
+use crate::types::{Endpoints, ExportType, NvmeofConnectOptions};
 
 /// Base IQN prefix for iSCSI targets (must match ctld-agent configuration)
 const BASE_IQN: &str = "iqn.2024-01.org.freebsd.csi";
@@ -586,8 +586,20 @@ impl csi::node_server::Node for NodeService {
             }
             ExportType::Nvmeof => {
                 let nvme_creds = Self::extract_nvme_auth(secrets);
-                platform::connect_nvmeof(target_name, endpoints.as_slice(), nvme_creds.as_ref())
-                    .await?
+                let connect_options = NvmeofConnectOptions::parse(volume_context).map_err(|e| {
+                    Status::invalid_argument(format!(
+                        "Invalid NVMeoF connect option in volume context: {}",
+                        e
+                    ))
+                })?;
+
+                platform::connect_nvmeof(
+                    target_name,
+                    endpoints.as_slice(),
+                    nvme_creds.as_ref(),
+                    Some(&connect_options),
+                )
+                .await?
             }
         };
 

--- a/csi-driver/src/platform/linux.rs
+++ b/csi-driver/src/platform/linux.rs
@@ -13,7 +13,7 @@ use tonic::Status;
 use tracing::{debug, error, info, warn};
 
 use super::PlatformResult;
-use crate::types::Endpoint;
+use crate::types::{Endpoint, NvmeofConnectOptions};
 
 /// Default filesystem type for Linux
 pub const DEFAULT_FS_TYPE: &str = "ext4";
@@ -645,6 +645,7 @@ pub async fn connect_nvmeof(
     target_nqn: &str,
     endpoints: &[Endpoint],
     auth_credentials: Option<&NvmeAuthCredentials>,
+    connect_options: Option<&NvmeofConnectOptions>,
 ) -> PlatformResult<String> {
     if endpoints.is_empty() {
         return Err(Status::invalid_argument(
@@ -667,14 +668,9 @@ pub async fn connect_nvmeof(
 
     // Connect to each endpoint (each with its own host:port)
     for endpoint in endpoints {
-        let addr = &endpoint.host;
-        let port = endpoint.port.to_string();
-
-        // Build nvme connect command with optional authentication
         let mut cmd = Command::new("nvme");
-        cmd.args([
-            "connect", "-t", "tcp", "-a", addr, "-s", &port, "-n", target_nqn,
-        ]);
+        let args = build_nvme_connect_args(target_nqn, endpoint, connect_options, auth_credentials);
+        cmd.args(&args);
 
         if let Some(auth) = auth_credentials {
             debug!(
@@ -683,12 +679,6 @@ pub async fn connect_nvmeof(
                 has_ctrl_secret = auth.ctrl_secret.is_some(),
                 "Configuring NVMeoF DH-HMAC-CHAP authentication"
             );
-
-            cmd.args(["--dhchap-secret", &auth.secret]);
-
-            if let Some(ctrl_secret) = &auth.ctrl_secret {
-                cmd.args(["--dhchap-ctrl-secret", ctrl_secret]);
-            }
         }
 
         let output = cmd.output().await.map_err(|e| {
@@ -748,6 +738,63 @@ pub async fn connect_nvmeof(
     );
 
     Ok(device)
+}
+
+fn build_nvme_connect_args(
+    target_nqn: &str,
+    endpoint: &Endpoint,
+    connect_options: Option<&NvmeofConnectOptions>,
+    auth_credentials: Option<&NvmeAuthCredentials>,
+) -> Vec<String> {
+    let mut args = vec![
+        "connect".to_string(),
+        "-t".to_string(),
+        "tcp".to_string(),
+        "-a".to_string(),
+        endpoint.host.clone(),
+        "-s".to_string(),
+        endpoint.port.to_string(),
+        "-n".to_string(),
+        target_nqn.to_string(),
+    ];
+
+    if let Some(options) = connect_options {
+        if let Some(value) = options.nr_io_queues {
+            args.push(format!("--nr-io-queues={}", value));
+        }
+
+        if let Some(value) = options.queue_size {
+            args.push(format!("--queue-size={}", value));
+        }
+
+        if options.disable_sqflow == Some(true) {
+            args.push("--disable-sqflow".to_string());
+        }
+
+        if let Some(value) = options.keep_alive_tmo {
+            args.push(format!("--keep-alive-tmo={}", value));
+        }
+
+        if let Some(value) = options.reconnect_delay {
+            args.push(format!("--reconnect-delay={}", value));
+        }
+
+        if let Some(value) = options.ctrl_loss_tmo {
+            args.push(format!("--ctrl-loss-tmo={}", value));
+        }
+    }
+
+    if let Some(auth) = auth_credentials {
+        args.push("--dhchap-secret".to_string());
+        args.push(auth.secret.clone());
+
+        if let Some(ctrl_secret) = &auth.ctrl_secret {
+            args.push("--dhchap-ctrl-secret".to_string());
+            args.push(ctrl_secret.clone());
+        }
+    }
+
+    args
 }
 
 /// Check if a device path is an NVMe namespace device (nvmeXnY) not just a controller (nvmeX).
@@ -1271,5 +1318,64 @@ mod tests {
         assert!(!is_nvme_namespace_device("/dev/nvme"));
         assert!(!is_nvme_namespace_device(""));
         assert!(!is_nvme_namespace_device("/dev/nvme0n")); // Missing namespace number
+    }
+
+    #[test]
+    fn test_build_nvme_connect_args_includes_connect_options() {
+        let endpoint = Endpoint::new("10.0.0.10", 4420);
+        let options = crate::types::NvmeofConnectOptions {
+            nr_io_queues: Some(2),
+            queue_size: Some(128),
+            disable_sqflow: Some(true),
+            keep_alive_tmo: Some(5),
+            reconnect_delay: Some(2),
+            ctrl_loss_tmo: Some(60),
+        };
+
+        let args = build_nvme_connect_args(
+            "nqn.2024-01.org.freebsd.csi:test",
+            &endpoint,
+            Some(&options),
+            None,
+        );
+
+        assert_eq!(
+            args,
+            vec![
+                "connect",
+                "-t",
+                "tcp",
+                "-a",
+                "10.0.0.10",
+                "-s",
+                "4420",
+                "-n",
+                "nqn.2024-01.org.freebsd.csi:test",
+                "--nr-io-queues=2",
+                "--queue-size=128",
+                "--disable-sqflow",
+                "--keep-alive-tmo=5",
+                "--reconnect-delay=2",
+                "--ctrl-loss-tmo=60",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_build_nvme_connect_args_omits_false_disable_sqflow() {
+        let endpoint = Endpoint::new("10.0.0.10", 4420);
+        let options = crate::types::NvmeofConnectOptions {
+            disable_sqflow: Some(false),
+            ..Default::default()
+        };
+
+        let args = build_nvme_connect_args(
+            "nqn.2024-01.org.freebsd.csi:test",
+            &endpoint,
+            Some(&options),
+            None,
+        );
+
+        assert!(!args.iter().any(|arg| arg == "--disable-sqflow"));
     }
 }

--- a/csi-driver/src/types.rs
+++ b/csi-driver/src/types.rs
@@ -217,6 +217,135 @@ impl Display for ProvisioningModeParseError {
 impl std::error::Error for ProvisioningModeParseError {}
 
 // ============================================================================
+// NvmeofConnectOptions
+// ============================================================================
+
+/// Optional Linux NVMe/TCP initiator options for `nvme connect`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NvmeofConnectOptions {
+    /// Number of I/O queues (`--nr-io-queues`).
+    pub nr_io_queues: Option<u32>,
+    /// Submission queue size (`--queue-size`).
+    pub queue_size: Option<u32>,
+    /// Disable SQ flow control (`--disable-sqflow`).
+    pub disable_sqflow: Option<bool>,
+    /// Keepalive timeout in seconds (`--keep-alive-tmo`).
+    pub keep_alive_tmo: Option<u32>,
+    /// Reconnect delay in seconds (`--reconnect-delay`).
+    pub reconnect_delay: Option<u32>,
+    /// Controller loss timeout in seconds (`--ctrl-loss-tmo`).
+    pub ctrl_loss_tmo: Option<u32>,
+}
+
+impl NvmeofConnectOptions {
+    pub const NR_IO_QUEUES_PARAM: &'static str = "nvmeof.nrIoQueues";
+    pub const QUEUE_SIZE_PARAM: &'static str = "nvmeof.queueSize";
+    pub const DISABLE_SQFLOW_PARAM: &'static str = "nvmeof.disableSqflow";
+    pub const KEEP_ALIVE_TMO_PARAM: &'static str = "nvmeof.keepAliveTmo";
+    pub const RECONNECT_DELAY_PARAM: &'static str = "nvmeof.reconnectDelay";
+    pub const CTRL_LOSS_TMO_PARAM: &'static str = "nvmeof.ctrlLossTmo";
+
+    pub const PARAM_NAMES: &'static [&'static str] = &[
+        Self::NR_IO_QUEUES_PARAM,
+        Self::QUEUE_SIZE_PARAM,
+        Self::DISABLE_SQFLOW_PARAM,
+        Self::KEEP_ALIVE_TMO_PARAM,
+        Self::RECONNECT_DELAY_PARAM,
+        Self::CTRL_LOSS_TMO_PARAM,
+    ];
+
+    /// Parse NVMeoF connect options from StorageClass parameters or volume context.
+    pub fn parse(
+        parameters: &std::collections::HashMap<String, String>,
+    ) -> Result<Self, NvmeofConnectOptionsParseError> {
+        Ok(Self {
+            nr_io_queues: parse_positive_u32(parameters, Self::NR_IO_QUEUES_PARAM)?,
+            queue_size: parse_positive_u32(parameters, Self::QUEUE_SIZE_PARAM)?,
+            disable_sqflow: parse_bool(parameters, Self::DISABLE_SQFLOW_PARAM)?,
+            keep_alive_tmo: parse_positive_u32(parameters, Self::KEEP_ALIVE_TMO_PARAM)?,
+            reconnect_delay: parse_positive_u32(parameters, Self::RECONNECT_DELAY_PARAM)?,
+            ctrl_loss_tmo: parse_positive_u32(parameters, Self::CTRL_LOSS_TMO_PARAM)?,
+        })
+    }
+
+    /// Return true when at least one option is set.
+    pub const fn has_options(&self) -> bool {
+        self.nr_io_queues.is_some()
+            || self.queue_size.is_some()
+            || self.disable_sqflow.is_some()
+            || self.keep_alive_tmo.is_some()
+            || self.reconnect_delay.is_some()
+            || self.ctrl_loss_tmo.is_some()
+    }
+}
+
+fn parse_positive_u32(
+    parameters: &std::collections::HashMap<String, String>,
+    key: &'static str,
+) -> Result<Option<u32>, NvmeofConnectOptionsParseError> {
+    let Some(value) = parameters.get(key) else {
+        return Ok(None);
+    };
+
+    let parsed = value
+        .parse::<u32>()
+        .map_err(|_| NvmeofConnectOptionsParseError {
+            key,
+            value: value.clone(),
+            expected: "a positive integer",
+        })?;
+
+    if parsed == 0 {
+        return Err(NvmeofConnectOptionsParseError {
+            key,
+            value: value.clone(),
+            expected: "a positive integer",
+        });
+    }
+
+    Ok(Some(parsed))
+}
+
+fn parse_bool(
+    parameters: &std::collections::HashMap<String, String>,
+    key: &'static str,
+) -> Result<Option<bool>, NvmeofConnectOptionsParseError> {
+    let Some(value) = parameters.get(key) else {
+        return Ok(None);
+    };
+
+    match value.to_lowercase().as_str() {
+        "true" | "1" | "yes" => Ok(Some(true)),
+        "false" | "0" | "no" => Ok(Some(false)),
+        _ => Err(NvmeofConnectOptionsParseError {
+            key,
+            value: value.clone(),
+            expected: "true or false",
+        }),
+    }
+}
+
+/// Error returned when parsing invalid NVMeoF connect options.
+#[derive(Debug, Clone)]
+pub struct NvmeofConnectOptionsParseError {
+    key: &'static str,
+    value: String,
+    expected: &'static str,
+}
+
+impl Display for NvmeofConnectOptionsParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid {} value '{}': expected {}",
+            self.key, self.value, self.expected
+        )
+    }
+}
+
+impl std::error::Error for NvmeofConnectOptionsParseError {}
+
+// ============================================================================
 // Endpoint
 // ============================================================================
 
@@ -508,6 +637,54 @@ mod tests {
     fn test_provisioning_mode_requires_reservation() {
         assert!(!ProvisioningMode::Thin.requires_reservation());
         assert!(ProvisioningMode::Thick.requires_reservation());
+    }
+
+    #[test]
+    fn test_nvmeof_connect_options_parse_all_values() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("nvmeof.nrIoQueues".to_string(), "2".to_string());
+        params.insert("nvmeof.queueSize".to_string(), "128".to_string());
+        params.insert("nvmeof.disableSqflow".to_string(), "true".to_string());
+        params.insert("nvmeof.keepAliveTmo".to_string(), "5".to_string());
+        params.insert("nvmeof.reconnectDelay".to_string(), "2".to_string());
+        params.insert("nvmeof.ctrlLossTmo".to_string(), "60".to_string());
+
+        let options = NvmeofConnectOptions::parse(&params).unwrap();
+
+        assert_eq!(options.nr_io_queues, Some(2));
+        assert_eq!(options.queue_size, Some(128));
+        assert_eq!(options.disable_sqflow, Some(true));
+        assert_eq!(options.keep_alive_tmo, Some(5));
+        assert_eq!(options.reconnect_delay, Some(2));
+        assert_eq!(options.ctrl_loss_tmo, Some(60));
+    }
+
+    #[test]
+    fn test_nvmeof_connect_options_absent_is_empty() {
+        let params = std::collections::HashMap::new();
+        let options = NvmeofConnectOptions::parse(&params).unwrap();
+
+        assert!(!options.has_options());
+    }
+
+    #[test]
+    fn test_nvmeof_connect_options_rejects_zero_numeric_value() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("nvmeof.queueSize".to_string(), "0".to_string());
+
+        let err = NvmeofConnectOptions::parse(&params).unwrap_err();
+
+        assert!(err.to_string().contains("nvmeof.queueSize"));
+    }
+
+    #[test]
+    fn test_nvmeof_connect_options_rejects_invalid_bool() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("nvmeof.disableSqflow".to_string(), "maybe".to_string());
+
+        let err = NvmeofConnectOptions::parse(&params).unwrap_err();
+
+        assert!(err.to_string().contains("nvmeof.disableSqflow"));
     }
 
     // Endpoint tests

--- a/csi-driver/src/types.rs
+++ b/csi-driver/src/types.rs
@@ -262,7 +262,7 @@ impl NvmeofConnectOptions {
             nr_io_queues: parse_positive_u32(parameters, Self::NR_IO_QUEUES_PARAM)?,
             queue_size: parse_positive_u32(parameters, Self::QUEUE_SIZE_PARAM)?,
             disable_sqflow: parse_bool(parameters, Self::DISABLE_SQFLOW_PARAM)?,
-            keep_alive_tmo: parse_positive_u32(parameters, Self::KEEP_ALIVE_TMO_PARAM)?,
+            keep_alive_tmo: parse_non_negative_u32(parameters, Self::KEEP_ALIVE_TMO_PARAM)?,
             reconnect_delay: parse_positive_u32(parameters, Self::RECONNECT_DELAY_PARAM)?,
             ctrl_loss_tmo: parse_ctrl_loss_tmo(parameters)?,
         })
@@ -302,6 +302,25 @@ fn parse_positive_u32(
             expected: "a positive integer",
         });
     }
+
+    Ok(Some(parsed))
+}
+
+fn parse_non_negative_u32(
+    parameters: &std::collections::HashMap<String, String>,
+    key: &'static str,
+) -> Result<Option<u32>, NvmeofConnectOptionsParseError> {
+    let Some(value) = parameters.get(key) else {
+        return Ok(None);
+    };
+
+    let parsed = value
+        .parse::<u32>()
+        .map_err(|_| NvmeofConnectOptionsParseError {
+            key,
+            value: value.clone(),
+            expected: "zero or a positive integer",
+        })?;
 
     Ok(Some(parsed))
 }
@@ -702,6 +721,16 @@ mod tests {
         let err = NvmeofConnectOptions::parse(&params).unwrap_err();
 
         assert!(err.to_string().contains("nvmeof.queueSize"));
+    }
+
+    #[test]
+    fn test_nvmeof_connect_options_accepts_zero_keep_alive_tmo() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("nvmeof.keepAliveTmo".to_string(), "0".to_string());
+
+        let options = NvmeofConnectOptions::parse(&params).unwrap();
+
+        assert_eq!(options.keep_alive_tmo, Some(0));
     }
 
     #[test]

--- a/csi-driver/src/types.rs
+++ b/csi-driver/src/types.rs
@@ -234,7 +234,7 @@ pub struct NvmeofConnectOptions {
     /// Reconnect delay in seconds (`--reconnect-delay`).
     pub reconnect_delay: Option<u32>,
     /// Controller loss timeout in seconds (`--ctrl-loss-tmo`).
-    pub ctrl_loss_tmo: Option<u32>,
+    pub ctrl_loss_tmo: Option<i32>,
 }
 
 impl NvmeofConnectOptions {
@@ -264,7 +264,7 @@ impl NvmeofConnectOptions {
             disable_sqflow: parse_bool(parameters, Self::DISABLE_SQFLOW_PARAM)?,
             keep_alive_tmo: parse_positive_u32(parameters, Self::KEEP_ALIVE_TMO_PARAM)?,
             reconnect_delay: parse_positive_u32(parameters, Self::RECONNECT_DELAY_PARAM)?,
-            ctrl_loss_tmo: parse_positive_u32(parameters, Self::CTRL_LOSS_TMO_PARAM)?,
+            ctrl_loss_tmo: parse_ctrl_loss_tmo(parameters)?,
         })
     }
 
@@ -323,6 +323,33 @@ fn parse_bool(
             expected: "true or false",
         }),
     }
+}
+
+fn parse_ctrl_loss_tmo(
+    parameters: &std::collections::HashMap<String, String>,
+) -> Result<Option<i32>, NvmeofConnectOptionsParseError> {
+    let key = NvmeofConnectOptions::CTRL_LOSS_TMO_PARAM;
+    let Some(value) = parameters.get(key) else {
+        return Ok(None);
+    };
+
+    let parsed = value
+        .parse::<i32>()
+        .map_err(|_| NvmeofConnectOptionsParseError {
+            key,
+            value: value.clone(),
+            expected: "-1, 0, or a positive integer",
+        })?;
+
+    if parsed < -1 {
+        return Err(NvmeofConnectOptionsParseError {
+            key,
+            value: value.clone(),
+            expected: "-1, 0, or a positive integer",
+        });
+    }
+
+    Ok(Some(parsed))
 }
 
 /// Error returned when parsing invalid NVMeoF connect options.
@@ -675,6 +702,26 @@ mod tests {
         let err = NvmeofConnectOptions::parse(&params).unwrap_err();
 
         assert!(err.to_string().contains("nvmeof.queueSize"));
+    }
+
+    #[test]
+    fn test_nvmeof_connect_options_accepts_negative_one_ctrl_loss_tmo() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("nvmeof.ctrlLossTmo".to_string(), "-1".to_string());
+
+        let options = NvmeofConnectOptions::parse(&params).unwrap();
+
+        assert_eq!(options.ctrl_loss_tmo, Some(-1));
+    }
+
+    #[test]
+    fn test_nvmeof_connect_options_rejects_ctrl_loss_tmo_less_than_negative_one() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("nvmeof.ctrlLossTmo".to_string(), "-2".to_string());
+
+        let err = NvmeofConnectOptions::parse(&params).unwrap_err();
+
+        assert!(err.to_string().contains("nvmeof.ctrlLossTmo"));
     }
 
     #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -337,7 +337,7 @@ These optional parameters are copied into the PV volume context and applied by t
 | `nvmeof.nrIoQueues` | positive integer | nvme-cli default | Number of I/O queues (`--nr-io-queues`) |
 | `nvmeof.queueSize` | positive integer | nvme-cli default | Queue size (`--queue-size`) |
 | `nvmeof.disableSqflow` | `true`, `false` | `false` | Disable SQ flow control (`--disable-sqflow`) |
-| `nvmeof.keepAliveTmo` | positive integer | nvme-cli default | Keepalive timeout in seconds (`--keep-alive-tmo`) |
+| `nvmeof.keepAliveTmo` | zero or positive integer | nvme-cli default | Keepalive timeout in seconds (`--keep-alive-tmo`); `0` disables keepalives |
 | `nvmeof.reconnectDelay` | positive integer | nvme-cli default | Reconnect delay in seconds (`--reconnect-delay`) |
 | `nvmeof.ctrlLossTmo` | `-1`, `0`, or positive integer | nvme-cli default | Controller loss timeout in seconds (`--ctrl-loss-tmo`); `-1` retries forever |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -339,7 +339,7 @@ These optional parameters are copied into the PV volume context and applied by t
 | `nvmeof.disableSqflow` | `true`, `false` | `false` | Disable SQ flow control (`--disable-sqflow`) |
 | `nvmeof.keepAliveTmo` | positive integer | nvme-cli default | Keepalive timeout in seconds (`--keep-alive-tmo`) |
 | `nvmeof.reconnectDelay` | positive integer | nvme-cli default | Reconnect delay in seconds (`--reconnect-delay`) |
-| `nvmeof.ctrlLossTmo` | positive integer | nvme-cli default | Controller loss timeout in seconds (`--ctrl-loss-tmo`) |
+| `nvmeof.ctrlLossTmo` | `-1`, `0`, or positive integer | nvme-cli default | Controller loss timeout in seconds (`--ctrl-loss-tmo`); `-1` retries forever |
 
 #### Block Device Parameters
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -328,6 +328,19 @@ StorageClass parameters control how volumes are provisioned:
 > For iSCSI, each portal will be discovered and logged into separately. For NVMeoF, each address will be connected separately.
 > Native multipath (NVMe) or dm-multipath (iSCSI) will combine the paths automatically.
 
+#### NVMeoF Initiator Connect Parameters
+
+These optional parameters are copied into the PV volume context and applied by the Linux node plugin when it runs `nvme connect`. They are ignored for iSCSI volumes.
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `nvmeof.nrIoQueues` | positive integer | nvme-cli default | Number of I/O queues (`--nr-io-queues`) |
+| `nvmeof.queueSize` | positive integer | nvme-cli default | Queue size (`--queue-size`) |
+| `nvmeof.disableSqflow` | `true`, `false` | `false` | Disable SQ flow control (`--disable-sqflow`) |
+| `nvmeof.keepAliveTmo` | positive integer | nvme-cli default | Keepalive timeout in seconds (`--keep-alive-tmo`) |
+| `nvmeof.reconnectDelay` | positive integer | nvme-cli default | Reconnect delay in seconds (`--reconnect-delay`) |
+| `nvmeof.ctrlLossTmo` | positive integer | nvme-cli default | Controller loss timeout in seconds (`--ctrl-loss-tmo`) |
+
 #### Block Device Parameters
 
 | Parameter | Values | Default | Description |
@@ -397,6 +410,9 @@ parameters:
   endpoints: "192.168.1.100:4420"  # REQUIRED (default port: 4420)
   blockSize: "4096"
   enableUnmap: "true"
+  nvmeof.nrIoQueues: "2"
+  nvmeof.queueSize: "128"
+  nvmeof.disableSqflow: "true"
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: Immediate


### PR DESCRIPTION
## Summary

Adds optional NVMe-oF initiator connect options from StorageClass parameters through to the Linux node-side `nvme connect` call.

Changes include:
- typed parsing and validation for `nvmeof.nrIoQueues`, `nvmeof.queueSize`, `nvmeof.disableSqflow`, `nvmeof.keepAliveTmo`, `nvmeof.reconnectDelay`, and `nvmeof.ctrlLossTmo`
- controller validation during `CreateVolume` and PV volume context preservation for NVMe-oF volumes
- node-side validation before attempting `nvme connect`
- Linux `nvme connect` argument construction for the selected options
- Helm chart and docs updates for the new parameters

Closes #56.

## Validation

- `cargo fmt --all`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `helm template freebsd-csi charts/freebsd-csi --kube-version 1.25.0 --show-only templates/storageclass.yaml --set agent.endpoint=http://10.0.0.1:50051 --set storageClassNvmeof.create=true --set storageClassNvmeof.parameters.endpoints=10.0.0.10:4420 --set storageClassNvmeof.parameters.nrIoQueues=2 --set storageClassNvmeof.parameters.queueSize=128 --set storageClassNvmeof.parameters.disableSqflow=true --set storageClassNvmeof.parameters.keepAliveTmo=5 --set storageClassNvmeof.parameters.reconnectDelay=2 --set storageClassNvmeof.parameters.ctrlLossTmo=60`