### PR TITLE
Preserve CSI metadata when volume deletion fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-trait"
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "csi-driver"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "clap",
  "hostname",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "ctld-agent"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "clap",
  "futures",

--- a/ctld-agent/src/service/storage.rs
+++ b/ctld-agent/src/service/storage.rs
@@ -231,6 +231,7 @@ fn volume_metadata_from_zfs(
         })?,
         parameters: zfs_meta.parameters.clone(),
         auth,
+        deletion_pending: zfs_meta.deletion_pending,
     })
 }
 
@@ -300,6 +301,7 @@ fn is_idempotent_create_request(
         && existing.lun_id == requested_lun_id as i32
         && existing.parameters == *requested_parameters
         && create_auth_matches(existing, requested_auth)
+        && !existing.deletion_pending
 }
 
 fn retry_failure_label(status: &Status) -> &'static str {
@@ -350,6 +352,8 @@ struct VolumeMetadata {
     parameters: HashMap<String, String>,
     /// Authentication configuration
     auth: AuthConfig,
+    /// Deletion has started; startup must not restore the export.
+    deletion_pending: bool,
 }
 
 /// gRPC Storage Agent service
@@ -467,6 +471,7 @@ impl StorageService {
                 })?,
                 parameters: zfs_meta.parameters.clone(),
                 auth,
+                deletion_pending: zfs_meta.deletion_pending,
             };
 
             volumes.insert(vol_name.clone(), metadata);
@@ -494,8 +499,18 @@ impl StorageService {
 
         let volumes = self.volumes.read().await;
         let mut reconciled_count = 0;
+        let mut deletion_pending_count = 0;
 
         for (vol_name, metadata) in volumes.iter() {
+            if metadata.deletion_pending {
+                deletion_pending_count += 1;
+                info!(
+                    volume = %vol_name,
+                    "Skipping export reconciliation for volume pending deletion"
+                );
+                continue;
+            }
+
             // Get device path for this volume
             let device_path = {
                 let zfs = self.zfs.read().await;
@@ -565,10 +580,11 @@ impl StorageService {
         drop(volumes);
 
         // Write unified UCL config after reconciliation
-        if reconciled_count > 0
-            && let Err(e) = self.config_writer.write_config().await
-        {
-            warn!("Failed to write CTL config after reconciliation: {}", e);
+        if reconciled_count > 0 || deletion_pending_count > 0 {
+            self.config_writer
+                .write_config()
+                .await
+                .map_err(|e| format!("failed to write CTL config after reconciliation: {}", e))?;
         }
 
         info!("Reconciled {} export(s)", reconciled_count);
@@ -1296,6 +1312,7 @@ impl StorageAgent for StorageService {
                 .map_err(|_| Status::internal(format!("LUN ID {} exceeds i32::MAX", lun_id)))?,
             parameters: req.parameters.clone(),
             auth: auth_config,
+            deletion_pending: false,
         };
 
         {
@@ -1529,6 +1546,25 @@ impl StorageAgent for StorageService {
             }
         };
 
+        // Persist the deletion state before removing the export. If destroy is
+        // temporarily blocked, startup can retain ownership without re-exporting it.
+        {
+            let zfs = self.zfs.read().await;
+            if let Err(e) = zfs.mark_volume_deletion_pending(&volume_name).await {
+                timer.failure("zfs_error");
+                return Err(Status::internal(format!(
+                    "failed to mark ZFS volume pending deletion: {}",
+                    e
+                )));
+            }
+        }
+        if let Some(metadata) = metadata.as_mut() {
+            metadata.deletion_pending = true;
+        }
+        if let Some(cached) = self.volumes.write().await.get_mut(&req.volume_id) {
+            cached.deletion_pending = true;
+        }
+
         // Try to unexport the volume via unified CTL manager
         // This is idempotent - if already unexported, we continue
         // Track whether we need to write config
@@ -1537,9 +1573,10 @@ impl StorageAgent for StorageService {
             match ctl.unexport_volume(&req.volume_id) {
                 Ok(()) => true,
                 Err(CtlError::TargetNotFound(_)) => {
-                    // Already unexported - this is fine (idempotent per CSI spec)
+                    // The in-memory export may be empty after restart while stale
+                    // generated config still exists, so force a config rewrite.
                     debug!("Volume {} already unexported (idempotent)", req.volume_id);
-                    false
+                    true
                 }
                 Err(e) => {
                     // Unexport failed - export is still active.
@@ -2260,7 +2297,7 @@ mod tests {
         let mut parameters = HashMap::new();
         parameters.insert("exportType".to_string(), "nvmeof".to_string());
 
-        let zfs_metadata = ZfsVolumeMetadata::new(
+        let mut zfs_metadata = ZfsVolumeMetadata::new(
             CtlExportType::Nvmeof,
             "nqn.2024-01.org.freebsd.csi:pvc-123".to_string(),
             Some(7),
@@ -2269,6 +2306,7 @@ mod tests {
             1234567890,
             Some("ag-pvc-123".to_string()),
         );
+        zfs_metadata.deletion_pending = true;
 
         let action = missing_metadata_delete_action(
             "pvc-123",
@@ -2286,6 +2324,7 @@ mod tests {
         assert_eq!(metadata.target_name, "nqn.2024-01.org.freebsd.csi:pvc-123");
         assert_eq!(metadata.lun_id, 7);
         assert_eq!(metadata.parameters, parameters);
+        assert!(metadata.deletion_pending);
         assert_eq!(
             metadata.auth,
             AuthConfig::GroupRef("ag-pvc-123".to_string())

--- a/ctld-agent/src/service/storage.rs
+++ b/ctld-agent/src/service/storage.rs
@@ -1041,7 +1041,7 @@ impl StorageAgent for StorageService {
                         .duration_since(std::time::UNIX_EPOCH)
                         .map(|d| d.as_millis())
                         .unwrap_or(0);
-                    let temp_snap_name = format!("pvc-clone-{}-{}", &req.name, timestamp);
+                    let temp_snap_name = format!("pvc-clone-{}-{}", req.name, timestamp);
 
                     info!(
                         source_volume = %source_volume_id,
@@ -1567,19 +1567,8 @@ impl StorageAgent for StorageService {
             )));
         }
 
-        // Clear ZFS metadata before deleting (for consistency)
-        {
-            let zfs = self.zfs.read().await;
-            if let Err(e) = zfs.clear_volume_metadata(&volume_name).await {
-                debug!(
-                    "Failed to clear volume metadata from ZFS: {} (may already be cleared)",
-                    e
-                );
-                // Continue anyway - we're deleting the volume
-            }
-        }
-
-        // Delete ZFS volume (this is now idempotent - returns Ok if doesn't exist)
+        // Keep the CSI ownership metadata until destroy succeeds so retries after
+        // an agent restart can still recognize a busy volume as CSI-managed.
         {
             let zfs = self.zfs.read().await;
             if let Err(e) = zfs.delete_volume(&volume_name).await {

--- a/ctld-agent/src/service/storage.rs
+++ b/ctld-agent/src/service/storage.rs
@@ -237,13 +237,8 @@ fn volume_metadata_from_zfs(
 
 fn create_retry_metadata(
     volume_id: &str,
-    cached_metadata: Option<VolumeMetadata>,
     metadata_lookup: std::result::Result<MissingMetadataLookup, crate::zfs::ZfsError>,
 ) -> Result<VolumeMetadata, Status> {
-    if let Some(metadata) = cached_metadata {
-        return Ok(metadata);
-    }
-
     let lookup = metadata_lookup.map_err(|e| match e {
         crate::zfs::ZfsError::InvalidName(msg) => {
             Status::invalid_argument(format!("invalid volume name '{}': {}", volume_id, msg))
@@ -290,24 +285,39 @@ fn create_auth_matches(existing: &VolumeMetadata, requested_auth: &AuthConfig) -
     auth_configs_match(&existing.name, &existing.auth, requested_auth)
 }
 
-fn is_idempotent_create_request(
+fn validate_idempotent_create_request(
     existing: &VolumeMetadata,
     requested_export_type: ExportType,
     requested_lun_id: u32,
     requested_parameters: &HashMap<String, String>,
     requested_auth: &AuthConfig,
-) -> bool {
-    existing.export_type == requested_export_type
+) -> Result<(), Status> {
+    if existing.deletion_pending {
+        return Err(Status::aborted(format!(
+            "Volume '{}' is pending deletion",
+            existing.name
+        )));
+    }
+
+    if existing.export_type == requested_export_type
         && existing.lun_id == requested_lun_id as i32
         && existing.parameters == *requested_parameters
         && create_auth_matches(existing, requested_auth)
-        && !existing.deletion_pending
+    {
+        return Ok(());
+    }
+
+    Err(Status::already_exists(format!(
+        "Volume '{}' already exists but requested export/auth parameters differ",
+        existing.name
+    )))
 }
 
 fn retry_failure_label(status: &Status) -> &'static str {
     match status.code() {
         tonic::Code::InvalidArgument => "invalid_argument",
         tonic::Code::AlreadyExists => "metadata_mismatch",
+        tonic::Code::Aborted => "deletion_pending",
         _ => "zfs_error",
     }
 }
@@ -713,33 +723,20 @@ impl StorageService {
             )));
         }
 
-        let cached_metadata = {
-            let volumes = self.volumes.read().await;
-            volumes.get(volume_name).cloned()
-        };
-
-        let metadata_lookup = if cached_metadata.is_some() {
-            Ok(MissingMetadataLookup::DatasetNotFound)
-        } else {
+        let metadata_lookup = {
             let zfs = self.zfs.read().await;
             zfs.get_volume_metadata(volume_name).await
         };
 
-        let existing_metadata =
-            create_retry_metadata(volume_name, cached_metadata, metadata_lookup)?;
+        let existing_metadata = create_retry_metadata(volume_name, metadata_lookup)?;
 
-        if !is_idempotent_create_request(
+        validate_idempotent_create_request(
             &existing_metadata,
             requested_export_type,
             requested_lun_id,
             requested_parameters,
             requested_auth,
-        ) {
-            return Err(Status::already_exists(format!(
-                "Volume '{}' already exists but requested export/auth parameters differ",
-                volume_name
-            )));
-        }
+        )?;
 
         Ok((existing, existing_metadata))
     }
@@ -1182,54 +1179,34 @@ impl StorageAgent for StorageService {
             }
         } else {
             // Fresh volume creation with metadata set atomically
-            let zfs = self.zfs.read().await;
-            match zfs
-                .create_volume(&req.name, req.size_bytes as u64, &zfs_metadata)
-                .await
-            {
+            let create_result = {
+                let zfs = self.zfs.read().await;
+                zfs.create_volume(&req.name, req.size_bytes as u64, &zfs_metadata)
+                    .await
+            };
+            match create_result {
                 Ok(d) => d,
                 Err(crate::zfs::ZfsError::DatasetExists(_)) => {
-                    // Recovery: Volume already exists - check if it matches requested parameters
-                    // This handles idempotent retries per CSI spec
-                    info!(
-                        volume = %req.name,
-                        "Volume already exists, checking parameters for idempotency"
-                    );
-
-                    // Get existing volume info to compare parameters
-                    let existing = match zfs.get_dataset(&req.name).await {
-                        Ok(d) => d,
-                        Err(e) => {
-                            timer.failure("zfs_error");
-                            return Err(Status::internal(format!(
-                                "Failed to get existing volume info: {}",
-                                e
-                            )));
+                    match self
+                        .recover_existing_volume_for_create(
+                            &req.name,
+                            req.size_bytes as u64,
+                            export_type,
+                            lun_id,
+                            &req.parameters,
+                            &auth_config,
+                        )
+                        .await
+                    {
+                        Ok((existing, existing_metadata)) => {
+                            target_name = existing_metadata.target_name.clone();
+                            existing
                         }
-                    };
-
-                    // Check size: existing >= requested is OK (volume may have been expanded)
-                    let existing_size = existing.volsize.unwrap_or(0);
-                    let requested_size = req.size_bytes as u64;
-
-                    if existing_size < requested_size {
-                        timer.failure("size_mismatch");
-                        return Err(Status::already_exists(format!(
-                            "Volume '{}' exists with size {} bytes but {} bytes was requested. \
-                             Existing volume is smaller than requested.",
-                            req.name, existing_size, requested_size
-                        )));
+                        Err(status) => {
+                            timer.failure(retry_failure_label(&status));
+                            return Err(status);
+                        }
                     }
-
-                    info!(
-                        volume = %req.name,
-                        existing_size = existing_size,
-                        requested_size = requested_size,
-                        "Existing volume matches requested parameters (idempotent success)"
-                    );
-
-                    // Return existing dataset info - continue with target export setup
-                    existing
                 }
                 Err(e) => {
                     timer.failure("zfs_error");
@@ -2290,6 +2267,32 @@ mod tests {
         let (result, next_token) = paginate(items, 0, "").unwrap();
         assert_eq!(result, vec![1, 2, 3]);
         assert!(next_token.is_empty());
+    }
+
+    #[test]
+    fn test_create_retry_rejects_volume_pending_deletion() {
+        let metadata = VolumeMetadata {
+            id: "pvc-123".to_string(),
+            name: "pvc-123".to_string(),
+            export_type: ExportType::Iscsi,
+            target_name: "iqn.2024-01.org.freebsd.csi:pvc-123".to_string(),
+            lun_id: 0,
+            parameters: HashMap::new(),
+            auth: AuthConfig::None,
+            deletion_pending: true,
+        };
+
+        let err = validate_idempotent_create_request(
+            &metadata,
+            ExportType::Iscsi,
+            0,
+            &HashMap::new(),
+            &AuthConfig::None,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code(), tonic::Code::Aborted);
+        assert!(err.message().contains("pending deletion"));
     }
 
     #[test]

--- a/ctld-agent/src/zfs/dataset.rs
+++ b/ctld-agent/src/zfs/dataset.rs
@@ -741,13 +741,9 @@ impl ZfsManager {
             .output()
             .await?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            warn!(volume = %full_name, error = %stderr, "Failed to set volume metadata");
-            return Err(ZfsError::CommandFailed(format!(
-                "failed to set metadata: {}",
-                stderr
-            )));
+        if let Err(e) = check_command_result(&output, &full_name) {
+            warn!(volume = %full_name, error = %e, "Failed to set volume metadata");
+            return Err(e);
         }
 
         debug!(volume = %full_name, "Volume metadata saved");
@@ -760,7 +756,10 @@ impl ZfsManager {
             VolumeMetadataLookup::Found(mut metadata) => {
                 if !metadata.deletion_pending {
                     metadata.deletion_pending = true;
-                    self.set_volume_metadata(name, &metadata).await?;
+                    match self.set_volume_metadata(name, &metadata).await {
+                        Ok(()) | Err(ZfsError::DatasetNotFound(_)) => {}
+                        Err(e) => return Err(e),
+                    }
                 }
                 Ok(())
             }
@@ -1458,6 +1457,21 @@ impl ZfsManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::process::ExitStatusExt;
+
+    #[test]
+    fn test_command_result_maps_vanished_dataset() {
+        let output = Output {
+            status: std::process::ExitStatus::from_raw(1),
+            stdout: Vec::new(),
+            stderr: b"cannot open 'tank/csi/vol1': dataset does not exist".to_vec(),
+        };
+
+        assert!(matches!(
+            check_command_result(&output, "tank/csi/vol1"),
+            Err(ZfsError::DatasetNotFound(_))
+        ));
+    }
 
     #[test]
     fn test_parse_size() {

--- a/ctld-agent/src/zfs/dataset.rs
+++ b/ctld-agent/src/zfs/dataset.rs
@@ -754,6 +754,24 @@ impl ZfsManager {
         Ok(())
     }
 
+    /// Mark a CSI volume as pending deletion before removing its export.
+    pub async fn mark_volume_deletion_pending(&self, name: &str) -> Result<()> {
+        match self.get_volume_metadata(name).await? {
+            VolumeMetadataLookup::Found(mut metadata) => {
+                if !metadata.deletion_pending {
+                    metadata.deletion_pending = true;
+                    self.set_volume_metadata(name, &metadata).await?;
+                }
+                Ok(())
+            }
+            VolumeMetadataLookup::DatasetNotFound => Ok(()),
+            VolumeMetadataLookup::MissingMetadata => Err(ZfsError::ParseError(format!(
+                "volume '{}' is missing CSI ownership metadata",
+                name
+            ))),
+        }
+    }
+
     /// Read CSI metadata for a single managed child volume.
     ///
     /// This distinguishes absent datasets from existing datasets without

--- a/ctld-agent/src/zfs/dataset.rs
+++ b/ctld-agent/src/zfs/dataset.rs
@@ -817,23 +817,6 @@ impl ZfsManager {
         Ok(VolumeMetadataLookup::Found(metadata))
     }
 
-    /// Clear volume metadata (on deletion)
-    #[instrument(skip(self))]
-    pub async fn clear_volume_metadata(&self, name: &str) -> Result<()> {
-        validate_name(name)?;
-        let full_name = self.full_path(name);
-
-        // Use 'inherit' to remove user property
-        let output = Command::new("zfs")
-            .args(["inherit", METADATA_PROPERTY, &full_name])
-            .output()
-            .await?;
-
-        // Ignore errors - property might not exist
-        let _ = output;
-        Ok(())
-    }
-
     /// List all volumes with CSI metadata (for startup recovery)
     #[instrument(skip(self))]
     pub async fn list_volumes_with_metadata(&self) -> Result<Vec<(String, VolumeMetadata)>> {

--- a/ctld-agent/src/zfs/properties.rs
+++ b/ctld-agent/src/zfs/properties.rs
@@ -7,7 +7,7 @@ use crate::ctl::ExportType;
 
 /// Current metadata schema version.
 /// Increment when making breaking changes to VolumeMetadata.
-pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+pub const CURRENT_SCHEMA_VERSION: u32 = 3;
 
 /// Metadata stored as ZFS user property for each volume
 ///
@@ -15,6 +15,7 @@ pub const CURRENT_SCHEMA_VERSION: u32 = 2;
 /// The `schema_version` field tracks the metadata format version.
 /// - Version 1: Original versioned format
 /// - Version 2: Standardized camelCase parameters
+/// - Version 3: Deletion-pending lifecycle marker
 ///
 /// Metadata without `schema_version` is not a valid CSI ownership marker.
 ///
@@ -158,7 +159,7 @@ mod tests {
     }
 
     #[test]
-    fn test_volume_metadata_explicit_v1_migration_to_v2() {
+    fn test_volume_metadata_explicit_v1_migration_to_current() {
         let mut params = HashMap::new();
         params.insert("fs_type".to_string(), "ext4".to_string());
         params.insert("block_size".to_string(), "4096".to_string());

--- a/ctld-agent/src/zfs/properties.rs
+++ b/ctld-agent/src/zfs/properties.rs
@@ -47,6 +47,9 @@ pub struct VolumeMetadata {
     /// None means "no-authentication".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_group: Option<String>,
+    /// Volume deletion has started and must not be re-exported.
+    #[serde(default)]
+    pub deletion_pending: bool,
 }
 
 impl VolumeMetadata {
@@ -69,6 +72,7 @@ impl VolumeMetadata {
             parameters,
             created_at,
             auth_group,
+            deletion_pending: false,
         }
     }
 
@@ -134,6 +138,7 @@ mod tests {
         );
 
         assert_eq!(metadata.schema_version, CURRENT_SCHEMA_VERSION);
+        assert!(!metadata.deletion_pending);
     }
 
     #[test]
@@ -244,11 +249,12 @@ mod tests {
 
         assert_eq!(metadata.schema_version, 2);
         assert_eq!(metadata.auth_group, Some("ag-vol1".to_string()));
+        assert!(!metadata.deletion_pending);
     }
 
     #[test]
     fn test_volume_metadata_roundtrip() {
-        let metadata = VolumeMetadata::new(
+        let mut metadata = VolumeMetadata::new(
             ExportType::Iscsi,
             "iqn.2024-01.org.freebsd.csi:vol1".to_string(),
             Some(0),
@@ -257,6 +263,7 @@ mod tests {
             1234567890,
             Some("ag-vol1".to_string()),
         );
+        metadata.deletion_pending = true;
 
         let json = serde_json::to_string(&metadata).unwrap();
         let parsed: VolumeMetadata = serde_json::from_str(&json).unwrap();
@@ -265,5 +272,6 @@ mod tests {
         assert_eq!(parsed.export_type, ExportType::Iscsi);
         assert_eq!(parsed.target_name, "iqn.2024-01.org.freebsd.csi:vol1");
         assert_eq!(parsed.auth_group, Some("ag-vol1".to_string()));
+        assert!(parsed.deletion_pending);
     }
 }


### PR DESCRIPTION
## Summary
- keep the CSI ownership property until ZFS destroy succeeds
- remove the now-unused metadata clearing helper
- fix the Rust 1.97 clippy failure on master
- update the two RustSec-flagged transitive dependencies

This keeps a busy volume recognizable as CSI-managed across ctld-agent restarts, allowing DeleteVolume retries to complete. A successful ZFS destroy removes the property with the dataset.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p csi-driver`
- `cargo test -p ctld-agent`
- `cargo audit`